### PR TITLE
Implement Typesense CLI

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+data

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,4 +5,10 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5.53", features = ["derive"] }
+git2 = "0.20.3"
+kdam = "0.6.3"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.148"
+serde_yaml = "0.9.34"
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }
+typesense = "0.3.0"

--- a/cli/src/commands/kampisos_init.rs
+++ b/cli/src/commands/kampisos_init.rs
@@ -1,0 +1,79 @@
+use typesense::apis::configuration::{ApiKey, Configuration};
+use typesense::collection_schema::CollectionSchemaBuilder;
+use typesense::field::Field;
+
+pub trait FieldExt {
+    fn index(self) -> Self;
+    fn optional(self) -> Self;
+    fn facet(self) -> Self;
+}
+
+impl FieldExt for Field {
+    fn index(mut self) -> Self {
+        self.index = Some(true);
+        self
+    }
+
+    fn optional(mut self) -> Self {
+        self.optional = Some(true);
+        self
+    }
+
+    fn facet(mut self) -> Self {
+        self.facet = Some(true);
+        self
+    }
+}
+
+pub async fn kampisos_init() -> Result<(), Box<dyn std::error::Error>> {
+    let collection_schema = CollectionSchemaBuilder::new(
+        "articles",
+        vec![
+            Field::new("book".into(), "string".into())
+                .facet()
+                .optional(),
+            Field::new("title".into(), "string".into()).optional(),
+            Field::new("url".into(), "string".into()).optional(),
+            Field::new("pronoun".into(), "string".into())
+                .facet()
+                .optional(),
+            Field::new("index".into(), "int32".into()).optional(),
+            Field::new("author".into(), "string".into())
+                .facet()
+                .optional(),
+            Field::new("dialect_v1".into(), "string[]".into())
+                .facet()
+                .optional(),
+            Field::new("dialect_v2".into(), "string[]".into())
+                .facet()
+                .optional(),
+            Field::new("dialect_v3".into(), "string[]".into())
+                .facet()
+                .optional(),
+            Field::new("writing_system".into(), "string".into()).optional(),
+            Field::new("text".into(), "string".into())
+                .index()
+                .optional(),
+            Field::new("translation".into(), "string".into())
+                .index()
+                .optional(),
+            Field::new("recorded_at".into(), "string".into()).optional(),
+            Field::new("published_at".into(), "string".into()).optional(),
+        ],
+    )
+    .build();
+
+    let configuration = Configuration {
+        base_path: "http://localhost:8108".to_owned(),
+        api_key: Some(ApiKey {
+            prefix: None,
+            key: "xyz".to_owned(),
+        }),
+        ..Default::default()
+    };
+
+    typesense::apis::collections_api::create_collection(&configuration, collection_schema).await?;
+    println!("Collection created successfully!");
+
+    Ok(())
+}

--- a/cli/src/commands/kampisos_sync.rs
+++ b/cli/src/commands/kampisos_sync.rs
@@ -1,0 +1,151 @@
+use crate::models::{Article, Dialect};
+use git2::{Repository, TreeWalkMode, TreeWalkResult};
+use kdam::tqdm;
+use serde_json::{Value, json};
+use serde_yaml;
+use typesense::apis::configuration::{ApiKey, Configuration};
+
+pub async fn kampisos_sync() -> Result<(), Box<dyn std::error::Error>> {
+    let repo = open_repository()?;
+
+    let mut articles: Vec<Article> = vec![];
+
+    let reference = repo.find_reference("refs/heads/main")?;
+    let tree = reference.peel_to_tree()?;
+
+    tree.walk(TreeWalkMode::PreOrder, |root, entry| {
+        let name = entry.name().unwrap_or("");
+        let path = format!("{}{}", root, name);
+
+        if !path.starts_with("texts") || !path.ends_with("yaml") {
+            return TreeWalkResult::Ok;
+        }
+
+        let object = entry.to_object(&repo).unwrap().peel_to_blob().unwrap();
+        let content = std::str::from_utf8(object.content()).unwrap();
+        let article: Article = serde_yaml::from_str(content).unwrap();
+
+        articles.push(article);
+
+        TreeWalkResult::Ok
+    })?;
+
+    let configuration = Configuration {
+        base_path: "http://localhost:8108".to_owned(),
+        api_key: Some(ApiKey {
+            prefix: None,
+            key: "xyz".to_owned(),
+        }),
+        ..Default::default()
+    };
+
+    for article in tqdm!(articles.iter()) {
+        for document in article.documents() {
+            typesense::apis::documents_api::index_document(
+                &configuration,
+                "articles",
+                document,
+                Some("upsert"),
+            )
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn open_repository() -> Result<Repository, Box<dyn std::error::Error>> {
+    let repo = Repository::open("/tmp/ainu-corpora")?;
+
+    return Ok(repo);
+}
+
+impl Dialect {
+    fn lv_n(&self, level: u8) -> Vec<String> {
+        let index = level.into();
+
+        match &self {
+            Dialect::Path(path) | Dialect::NamedPath { path, .. } => path
+                .split("/")
+                .nth(index)
+                .into_iter()
+                .map(|path| path.to_owned())
+                .collect(),
+
+            Dialect::NamedPathList { paths, .. } => paths
+                .iter()
+                .filter_map(|path| path.split("/").nth(index))
+                .map(|path| path.to_owned())
+                .collect(),
+        }
+    }
+
+    pub fn lv_1(&self) -> Vec<String> {
+        self.lv_n(0)
+    }
+
+    pub fn lv_2(&self) -> Vec<String> {
+        self.lv_n(1)
+    }
+
+    pub fn lv_3(&self) -> Vec<String> {
+        self.lv_n(2)
+    }
+}
+
+impl Article {
+    pub fn documents(&self) -> Vec<Value> {
+        self.sentences
+          .iter()
+          .enumerate()
+          .map(|(index, sentence)| {
+            json!({
+              "id": format!("{}/{}#{}", &self.book, &self.title, index),
+              "book": &self.book,
+              "title": &self.title,
+              "url": &self.url,
+              "pronoun": sentence.pronoun.as_ref().or(self.pronoun.as_ref()),
+              "index": index,
+              "author": sentence.author.as_ref().or(self.author.as_ref()),
+              "dialect_v1": sentence.dialect.as_ref().or(self.dialect.as_ref()).map(|d| d.lv_1()),
+              "dialect_v2": sentence.dialect.as_ref().or(self.dialect.as_ref()).map(|d| d.lv_2()),
+              "dialect_v3": sentence.dialect.as_ref().or(self.dialect.as_ref()).map(|d| d.lv_3()),
+              "writing_system": &self.writing_system,
+              "text": &sentence.ain,
+              "translation": &sentence.jpn,
+              "recorded_at": &self.recorded_at,
+              "published_at": &self.published_at,
+            })
+          })
+          .collect()
+    }
+}
+
+// fn clone_repository() -> Result<Repository, Box<dyn std::error::Error>> {
+//     // Prepare callbacks.
+//     let mut callbacks = RemoteCallbacks::new();
+//     callbacks.credentials(|_url, username_from_url, _allowed_types| {
+//         Cred::ssh_key(
+//             username_from_url.unwrap(),
+//             None,
+//             Path::new(&format!("{}/.ssh/id_rsa", env::var("HOME").unwrap())),
+//             None,
+//         )
+//     });
+//
+//     // Prepare fetch options.
+//     let mut fo = git2::FetchOptions::new();
+//     fo.remote_callbacks(callbacks);
+//
+//     // Prepare builder.
+//     let mut builder = git2::build::RepoBuilder::new();
+//     builder.fetch_options(fo);
+//
+//     // Clone the project.
+//     let repo = builder.clone(
+//         "git@github.com:aynumosir/ainu-corpora.git",
+//         Path::new("/tmp/ainu-corpora"),
+//     )?;
+//
+//     return Ok(repo);
+// }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,0 +1,5 @@
+mod kampisos_init;
+mod kampisos_sync;
+
+pub use kampisos_init::*;
+pub use kampisos_sync::*;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,29 @@
-fn main() {
-    println!("Hello, world!");
+mod commands;
+mod models;
+
+use clap::{Parser, Subcommand};
+use tokio;
+
+#[derive(Parser)]
+#[command(version, about, long_about=None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Init {},
+    Sync {},
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Some(Commands::Init {}) => commands::kampisos_init().await,
+        Some(Commands::Sync {}) => commands::kampisos_sync().await,
+        None => Ok(()),
+    }
 }

--- a/cli/src/models/article.rs
+++ b/cli/src/models/article.rs
@@ -1,0 +1,56 @@
+use crate::models::{Dialect, Sentence};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Article {
+    // 書籍・ウェブサイト名（リポジトリ内で一意）
+    pub book: String,
+
+    // 章タイトル（同じ book 内で一意）
+    pub title: String,
+
+    // 参照URL
+    pub url: String,
+
+    // 著者名
+    pub author: Option<String>,
+
+    // 方言
+    pub dialect: Option<Dialect>,
+
+    // 主な一人称
+    pub pronoun: Option<String>,
+
+    // 表記法（ain フィールド）
+    #[serde(default)]
+    pub writing_system: WritingSystem,
+
+    // 録音日（ISO 8601 日付 or 範囲）
+    pub recorded_at: Option<String>,
+
+    // 公開日（ISO 8601 日付 or 範囲）
+    pub published_at: Option<String>,
+
+    // 録音者
+    pub recorded_by: Option<String>,
+
+    // 翻訳者
+    pub translated_by: Option<String>,
+
+    // 文章一覧
+    pub sentences: Vec<Sentence>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WritingSystem {
+    Latin,
+    Kana,
+}
+
+impl Default for WritingSystem {
+    fn default() -> Self {
+        WritingSystem::Latin
+    }
+}

--- a/cli/src/models/dialect.rs
+++ b/cli/src/models/dialect.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Dialect {
+    Path(String),
+    NamedPath { name: String, path: String },
+    NamedPathList { name: String, paths: Vec<String> },
+}

--- a/cli/src/models/mod.rs
+++ b/cli/src/models/mod.rs
@@ -1,0 +1,7 @@
+mod article;
+mod dialect;
+mod sentence;
+
+pub use article::*;
+pub use dialect::*;
+pub use sentence::*;

--- a/cli/src/models/sentence.rs
+++ b/cli/src/models/sentence.rs
@@ -1,0 +1,33 @@
+use crate::models::Dialect;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Sentence {
+    // 著者名のオーバーライド
+    pub author: Option<String>,
+
+    // 方言のオーバーライド
+    pub dialect: Option<Dialect>,
+
+    // 主な一人称のオーバーライド
+    pub pronoun: Option<String>,
+
+    // アイヌ語の文章
+    pub ain: Option<String>,
+
+    // 日本語訳
+    pub jpn: Option<String>,
+
+    // ロシア語訳
+    pub rus: Option<String>,
+
+    // 英語訳
+    pub eng: Option<String>,
+
+    // ポーランド語訳
+    pub pol: Option<String>,
+
+    // ドイツ語訳
+    pub deu: Option<String>,
+}


### PR DESCRIPTION
### 最低限
- [x] YAML を型安全にパース
- [x] Typesense API を叩いてデータを同期
- [ ] クライアント側を更新
### オプション追加
- [ ] glob でフィルタリング
- [ ] コミットハッシュ指定できるようにしたい