### PR TITLE
fix: Boost bilingual search by factor 1/2

### DIFF
--- a/src/lib/elasticsearch-helper.ts
+++ b/src/lib/elasticsearch-helper.ts
@@ -163,6 +163,7 @@ export const buildSearchRequest = (
                   },
                 },
               ],
+              boost: 1 / 2,
             },
           },
         ],


### PR DESCRIPTION
### 「kar a kar a」

<img width="1557" height="1356" alt="image" src="https://github.com/user-attachments/assets/a6153a92-e12d-4672-b5f5-c46b84665b68" />

### 「ruwe ne」

<img width="1566" height="1349" alt="image" src="https://github.com/user-attachments/assets/672501b9-b023-4282-b0c4-b95b3eefcc10" />

### 普通のbilingual検索

<img width="1348" height="1086" alt="image" src="https://github.com/user-attachments/assets/e28ab6cc-4c24-45e2-bd48-c170d2422567" />
