### PR TITLE
fix: Use 'operator: AND' in bilingual search and boost by 10

### DIFF
--- a/src/lib/elasticsearch-helper.ts
+++ b/src/lib/elasticsearch-helper.ts
@@ -149,21 +149,25 @@ export const buildSearchRequest = (
                 {
                   bool: {
                     must: [
-                      { match: { text: { query } } },
-                      { match: { translation: { query } } },
+                      { match: { text: { query, operator: "AND" } } },
+                      { match: { translation: { query, operator: "AND" } } },
                     ],
                   },
                 },
                 {
                   bool: {
                     must: [
-                      { match: { text: { query, fuzziness: "AUTO" } } },
-                      { match: { translation: { query } } },
+                      {
+                        match: {
+                          text: { query, operator: "AND", fuzziness: "AUTO" },
+                        },
+                      },
+                      { match: { translation: { query, operator: "AND" } } },
                     ],
                   },
                 },
               ],
-              boost: 2,
+              boost: 10,
             },
           },
         ],


### PR DESCRIPTION
`operator: AND` must work now because we introduced char_filter in https://github.com/aynumosir/terraform/pull/9

- https://kampisos.aynu.io/ja/search?q=sam+%E9%9A%A3
- https://kampisos-git-improve-bilingual-neetlab.vercel.app/ja/search?q=sam+%E9%9A%A3